### PR TITLE
[FEATURE] Add time-based filtering to list_builds and list_buildsets

### DIFF
--- a/TIME_FILTERING.md
+++ b/TIME_FILTERING.md
@@ -1,0 +1,112 @@
+# Time-Based Filtering for Zuul MCP
+
+This document describes the new time-based filtering capabilities added to the `list_builds` and `list_buildsets` tools.
+
+## Overview
+
+The Zuul API does not natively support time-based filtering. This enhancement adds client-side time filtering to allow you to query builds and buildsets within specific time windows.
+
+## New Parameters
+
+Both `list_builds` and `list_buildsets` now support these additional parameters:
+
+- `completed_after` (string): Filter builds/buildsets completed after this time (ISO 8601 format)
+- `completed_before` (string): Filter builds/buildsets completed before this time (ISO 8601 format)
+- `started_after` (string): Filter builds/buildsets started after this time (ISO 8601 format)
+- `started_before` (string): Filter builds/buildsets started before this time (ISO 8601 format)
+
+## ISO 8601 Format
+
+All time parameters accept ISO 8601 formatted timestamps:
+
+- `"2026-04-18T00:00:00Z"` - UTC time (Z suffix)
+- `"2026-04-18T00:00:00+00:00"` - UTC with explicit offset
+- `"2026-04-18T14:30:00-05:00"` - With timezone offset
+- `"2026-04-18T14:30:00"` - No timezone (assumes UTC)
+
+## Usage Examples
+
+### Find builds that failed in the last 48 hours
+
+```python
+from datetime import datetime, timedelta, timezone
+
+# Calculate timestamp for 48 hours ago
+now = datetime.now(timezone.utc)
+two_days_ago = now - timedelta(hours=48)
+
+# Query builds
+result = await list_builds(
+    ctx=ctx,
+    result="FAILURE",
+    completed_after=two_days_ago.isoformat(),
+    limit=50
+)
+```
+
+### Find all builds for a project completed today
+
+```python
+from datetime import datetime, timezone
+
+# Today's date at midnight UTC
+today = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+
+result = await list_builds(
+    ctx=ctx,
+    project="openstack/nova",
+    completed_after=today.isoformat(),
+    limit=100
+)
+```
+
+### Find buildsets in a specific time window
+
+```python
+result = await list_buildsets(
+    ctx=ctx,
+    pipeline="check",
+    completed_after="2026-04-18T00:00:00Z",
+    completed_before="2026-04-19T00:00:00Z",
+    limit=50
+)
+```
+
+## Implementation Details
+
+### Client-Side Filtering
+
+Since the Zuul API doesn't support time-based filtering, the implementation:
+
+1. Fetches results from the API (with a 3x multiplier on `limit` when time filters are active)
+2. Parses timestamps from build/buildset objects
+3. Filters results based on the provided time criteria
+4. Returns the filtered results up to the requested `limit`
+
+### Timestamp Fields
+
+- **Builds**: Uses `end_time` for completion filters, `start_time` for start filters
+- **Buildsets**: Uses `last_build_end_time` for completion filters, `first_build_start_time` for start filters
+
+### Performance Considerations
+
+- Time filtering happens client-side after fetching from the API
+- When time filters are active, the tool automatically fetches up to 3x the requested limit (capped at 300) to account for filtering
+- For large time windows with many results, you may need to increase the `limit` parameter or use pagination with `skip`
+
+## Testing
+
+Run the test suite to verify the implementation:
+
+```bash
+uv run pytest tests/test_helpers.py::TestParseIsoTimestamp -v
+```
+
+## Future Enhancements
+
+Potential improvements could include:
+
+1. **Use `idx_min`/`idx_max` API parameters**: If Zuul's build indices are chronological, these could provide more efficient range-based filtering
+2. **Auto-pagination**: Automatically fetch additional pages when filtering reduces results below the requested limit
+3. **Relative time strings**: Support for "last 48h", "yesterday", etc.
+4. **Caching**: Cache timestamp-to-index mappings for more efficient queries

--- a/src/mcp_zuul/helpers.py
+++ b/src/mcp_zuul/helpers.py
@@ -8,6 +8,7 @@ import re
 import ssl
 import time as _time
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import quote, urlparse
 
@@ -362,3 +363,27 @@ def is_ssl_error(exc: httpx.ConnectError) -> bool:
 def clean(d: dict) -> dict:
     """Remove None, empty string, and empty list values to save tokens."""
     return {k: v for k, v in d.items() if v is not None and v != "" and v != []}
+
+
+def parse_iso_timestamp(ts_str: str) -> datetime | None:
+    """Parse ISO 8601 timestamp string to timezone-aware datetime.
+
+    Handles formats like:
+        - "2026-04-18T00:00:00Z"
+        - "2026-04-18T00:00:00+00:00"
+        - "2026-04-18T14:30:00"
+
+    Returns None if parsing fails.
+    """
+    if not ts_str:
+        return None
+    try:
+        # Replace 'Z' with '+00:00' for fromisoformat compatibility
+        normalized = ts_str.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+        # If no timezone info, assume UTC
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+    except (ValueError, AttributeError):
+        return None

--- a/src/mcp_zuul/tools/_builds.py
+++ b/src/mcp_zuul/tools/_builds.py
@@ -10,7 +10,7 @@ from mcp.server.fastmcp import Context
 from ..classifier import Classification, classify_failure, determine_failure_phase
 from ..errors import handle_errors
 from ..formatters import fmt_build, fmt_buildset
-from ..helpers import api, app, clean, safepath, stream_log, strip_ansi
+from ..helpers import api, app, clean, parse_iso_timestamp, safepath, stream_log, strip_ansi
 from ..helpers import tenant as _tenant
 from ..parsers import grep_log_context
 from ..server import mcp
@@ -114,6 +114,10 @@ async def list_builds(
     patchset: str = "",
     ref: str = "",
     result: str = "",
+    completed_after: str = "",
+    completed_before: str = "",
+    started_after: str = "",
+    started_before: str = "",
     limit: int = 20,
     skip: int = 0,
 ) -> str:
@@ -129,12 +133,32 @@ async def list_builds(
         patchset: Filter by patchset
         ref: Filter by git ref
         result: Filter by result (SUCCESS, FAILURE, TIMED_OUT, SKIPPED, etc.)
+        completed_after: Filter builds completed after this time (ISO 8601, e.g. "2026-04-18T00:00:00Z")
+        completed_before: Filter builds completed before this time (ISO 8601)
+        started_after: Filter builds started after this time (ISO 8601)
+        started_before: Filter builds started before this time (ISO 8601)
         limit: Max results, 1-100 (default 20)
         skip: Offset for pagination (default 0)
     """
     t = _tenant(ctx, tenant)
     limit = max(1, min(limit, 100))
-    params: dict[str, Any] = {"limit": limit + 1, "skip": skip}
+
+    # Parse time filters
+    completed_after_dt = parse_iso_timestamp(completed_after) if completed_after else None
+    completed_before_dt = parse_iso_timestamp(completed_before) if completed_before else None
+    started_after_dt = parse_iso_timestamp(started_after) if started_after else None
+    started_before_dt = parse_iso_timestamp(started_before) if started_before else None
+
+    # Check if any time filters are active
+    has_time_filter = any(
+        [completed_after_dt, completed_before_dt, started_after_dt, started_before_dt]
+    )
+
+    # When time filtering is active, fetch more results initially to account for filtering
+    # Use 3x multiplier but cap at 300 to avoid excessive API calls
+    fetch_limit = min(limit * 3, 300) if has_time_filter else limit
+
+    params: dict[str, Any] = {"limit": fetch_limit + 1, "skip": skip}
     for key, val in [
         ("project", project),
         ("pipeline", pipeline),
@@ -149,6 +173,35 @@ async def list_builds(
             params[key] = val
 
     data = await api(ctx, f"/tenant/{safepath(t)}/builds", params)
+
+    # Apply time-based filtering if any time parameters were provided
+    if has_time_filter:
+        filtered = []
+        for build in data:
+            # Parse build timestamps
+            end_time = parse_iso_timestamp(build.get("end_time", ""))
+            start_time = parse_iso_timestamp(build.get("start_time", ""))
+
+            # Apply completed_after filter
+            if completed_after_dt and end_time and end_time < completed_after_dt:
+                continue
+
+            # Apply completed_before filter
+            if completed_before_dt and end_time and end_time > completed_before_dt:
+                continue
+
+            # Apply started_after filter
+            if started_after_dt and start_time and start_time < started_after_dt:
+                continue
+
+            # Apply started_before filter
+            if started_before_dt and start_time and start_time > started_before_dt:
+                continue
+
+            filtered.append(build)
+
+        data = filtered
+
     has_more = len(data) > limit
     builds = [fmt_build(b) for b in data[:limit]]
     return json.dumps({"builds": builds, "count": len(builds), "has_more": has_more})
@@ -399,6 +452,10 @@ async def list_buildsets(
     branch: str = "",
     ref: str = "",
     result: str = "",
+    completed_after: str = "",
+    completed_before: str = "",
+    started_after: str = "",
+    started_before: str = "",
     limit: int = 20,
     skip: int = 0,
     include_builds: bool = False,
@@ -413,6 +470,10 @@ async def list_buildsets(
         branch: Filter by branch name
         ref: Filter by git ref
         result: Filter by result
+        completed_after: Filter buildsets completed after this time (ISO 8601, e.g. "2026-04-18T00:00:00Z")
+        completed_before: Filter buildsets completed before this time (ISO 8601)
+        started_after: Filter buildsets started after this time (ISO 8601)
+        started_before: Filter buildsets started before this time (ISO 8601)
         limit: Max results, 1-100 (default 20)
         skip: Offset for pagination
         include_builds: Fetch full details (builds, events) for each buildset.
@@ -421,7 +482,22 @@ async def list_buildsets(
     """
     t = _tenant(ctx, tenant)
     limit = max(1, min(limit, 100))
-    params: dict[str, Any] = {"limit": limit + 1, "skip": skip}
+
+    # Parse time filters
+    completed_after_dt = parse_iso_timestamp(completed_after) if completed_after else None
+    completed_before_dt = parse_iso_timestamp(completed_before) if completed_before else None
+    started_after_dt = parse_iso_timestamp(started_after) if started_after else None
+    started_before_dt = parse_iso_timestamp(started_before) if started_before else None
+
+    # Check if any time filters are active
+    has_time_filter = any(
+        [completed_after_dt, completed_before_dt, started_after_dt, started_before_dt]
+    )
+
+    # When time filtering is active, fetch more results initially
+    fetch_limit = min(limit * 3, 300) if has_time_filter else limit
+
+    params: dict[str, Any] = {"limit": fetch_limit + 1, "skip": skip}
     for key, val in [
         ("project", project),
         ("pipeline", pipeline),
@@ -434,6 +510,36 @@ async def list_buildsets(
             params[key] = val
 
     data = await api(ctx, f"/tenant/{safepath(t)}/buildsets", params)
+
+    # Apply time-based filtering if any time parameters were provided
+    if has_time_filter:
+        filtered = []
+        for buildset in data:
+            # Parse buildset timestamps
+            # Buildsets may have first_build_start_time and last_build_end_time
+            first_start = parse_iso_timestamp(buildset.get("first_build_start_time", ""))
+            last_end = parse_iso_timestamp(buildset.get("last_build_end_time", ""))
+
+            # Apply completed_after filter
+            if completed_after_dt and last_end and last_end < completed_after_dt:
+                continue
+
+            # Apply completed_before filter
+            if completed_before_dt and last_end and last_end > completed_before_dt:
+                continue
+
+            # Apply started_after filter
+            if started_after_dt and first_start and first_start < started_after_dt:
+                continue
+
+            # Apply started_before filter
+            if started_before_dt and first_start and first_start > started_before_dt:
+                continue
+
+            filtered.append(buildset)
+
+        data = filtered
+
     has_more = len(data) > limit
     trimmed = data[:limit]
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,6 +18,7 @@ from mcp_zuul.helpers import (
     error,
     fetch_log_url,
     is_ssl_error,
+    parse_iso_timestamp,
     parse_zuul_url,
     safepath,
     strip_ansi,
@@ -143,6 +144,47 @@ class TestParseZuulUrl:
 
     def test_not_a_url(self):
         assert parse_zuul_url("just-a-string") is None
+
+
+class TestParseIsoTimestamp:
+    def test_parses_zulu_time(self):
+        from datetime import UTC
+
+        result = parse_iso_timestamp("2026-04-18T14:30:00Z")
+        assert result is not None
+        assert result.year == 2026
+        assert result.month == 4
+        assert result.day == 18
+        assert result.hour == 14
+        assert result.minute == 30
+        assert result.tzinfo == UTC
+
+    def test_parses_utc_offset(self):
+        result = parse_iso_timestamp("2026-04-18T14:30:00+00:00")
+        assert result is not None
+        assert result.year == 2026
+        assert result.hour == 14
+
+    def test_parses_no_timezone_assumes_utc(self):
+        from datetime import UTC
+
+        result = parse_iso_timestamp("2026-04-18T14:30:00")
+        assert result is not None
+        assert result.tzinfo == UTC
+
+    def test_parses_with_timezone_offset(self):
+        result = parse_iso_timestamp("2026-04-18T14:30:00-05:00")
+        assert result is not None
+        assert result.year == 2026
+
+    def test_empty_string_returns_none(self):
+        assert parse_iso_timestamp("") is None
+
+    def test_invalid_format_returns_none(self):
+        assert parse_iso_timestamp("not-a-date") is None
+
+    def test_none_returns_none(self):
+        assert parse_iso_timestamp(None) is None  # type: ignore[arg-type]
 
 
 class TestConfig:


### PR DESCRIPTION
Adds client-side time filtering for querying builds and buildsets within specific time windows, addressing the limitation that Zuul's API doesn't provide native time-based query parameters.  When filtering for multiple jobs within a certain time window, e.g. how many jobs failed due to `ssl.SSLCertVerificationError` in the last 12 hours I would get inconsistent results.  Sometimes the the LLM would report accurately but there were other times where it would provide results well outside of the requested window.  Adding a time filter optimized query to help ensure results fell within requested time window.

Changes:
- Add parse_iso_timestamp() helper function in helpers.py to parse ISO 8601 timestamps with timezone support
- Add 4 new parameters to list_builds(): completed_after, completed_before, started_after, started_before
- Add same 4 time parameters to list_buildsets()
- Implement client-side filtering based on build/buildset timestamps
- Auto-fetch 3x limit (capped at 300) when time filters are active to account for filtering
- Add comprehensive tests for timestamp parsing
- Add TIME_FILTERING.md documentation with usage examples

Time filters accept ISO 8601 format (e.g., "2026-04-18T00:00:00Z") and filter builds by end_time/start_time, buildsets by last_build_end_time/ first_build_start_time.

All existing tests pass (99 tests in test_helpers.py).

## Testing

- [ ] `uv run pytest tests/ -v` — all tests pass
- [ ] `uv run ruff check src/ tests/` — no lint errors
- [ ] `uv run mypy src/mcp_zuul/` — no type errors
- [ ] New tests added for new functionality

Assisted-By: Claude Code
Signed-off-by: James Parker <jparker@redhat.com>