### PR TITLE
fix: use absolute URLs to support Zuul deployments behind a sub-path

### DIFF
--- a/src/mcp_zuul/helpers.py
+++ b/src/mcp_zuul/helpers.py
@@ -65,7 +65,10 @@ async def api(ctx: Context, path: str, params: dict | None = None) -> Any:
     re-authenticates via Kerberos on 401.
     """
     a = app(ctx)
-    url = f"/api{path}"
+    # Use an absolute URL so deployments behind a sub-path (e.g. /zuul/) work.
+    # A path-absolute reference like "/api/..." would strip any prefix from
+    # base_url during httpx URL resolution (RFC 3986 §5.2).
+    url = f"{a.config.base_url}/api{path}"
 
     for attempt in range(2):
         resp = await a.client.get(url, params=params)
@@ -107,7 +110,7 @@ async def _api_mutate(ctx: Context, method: str, path: str, body: dict | None = 
     a = app(ctx)
     if a.config.read_only:
         raise ValueError("Write operations disabled (ZUUL_READ_ONLY=true)")
-    url = f"/api{path}"
+    url = f"{a.config.base_url}/api{path}"
 
     for attempt in range(2):
         if method == "POST":


### PR DESCRIPTION
## Problem

When Zuul is deployed behind a reverse-proxy sub-path (e.g. `/zuul/`), the user sets `ZUUL_URL=https://host/zuul`. However, API calls were built as path-absolute references:

```python
url = f"/api{path}"  # e.g. /api/tenant/my-tenant/pipelines
```

Per [RFC 3986 §5.2](https://www.rfc-editor.org/rfc/rfc3986#section-5.2), a reference starting with `/` replaces the entire path of the base URL. So httpx resolves:

```
base_url = https://host/zuul
url      = /api/tenant/my-tenant/pipelines
result   → https://host/api/tenant/my-tenant/pipelines  ❌ (404)
```

The `/zuul` prefix is stripped, and all API calls land on the wrong path.

The same issue affects `kerberos_auth`, which calls `f"{base_url}/api/tenants"` for the initial auth handshake — this part already works correctly since it uses string concatenation. Only the `api()` and `_api_mutate()` helpers were affected.

## Fix

Build API URLs using `f"{a.config.base_url}/api{path}"` (absolute URL) instead of the path-absolute `f"/api{path}"`. This is a no-op for root deployments (`base_url = https://host`) and correctly preserves any sub-path prefix for proxied deployments.

## Testing

All 616 existing tests pass unchanged — the test fixtures use `base_url="https://zuul.example.com"` (no sub-path), so the constructed URL is identical to before.

Verified manually against a Zuul deployment proxied at `/zuul/` using Kerberos auth.