### PR TITLE
Add live console streaming for running builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-MCP server for Zuul CI — 36 tools (31 read-only + 4 write + 1 LogJuicer), 3 prompts, and 3 resources exposing builds, logs, pipelines, jobs, infrastructure, and live status via the Model Context Protocol. Published on PyPI as `mcp-zuul`. Supports stdio, SSE, and streamable-http transports.
+MCP server for Zuul CI — 37 tools (31 read-only + 4 write + 1 LogJuicer + 1 console stream), 3 prompts, and 3 resources exposing builds, logs, pipelines, jobs, infrastructure, and live status via the Model Context Protocol. Published on PyPI as `mcp-zuul`. Supports stdio, SSE, and streamable-http transports.
 
 ## Commands
 
@@ -42,6 +42,7 @@ tools/             →  Package: 36 @mcp.tool() functions split by domain
   __init__.py      →  Re-exports for backward compat (tests import from mcp_zuul.tools)
   _common.py       →  Shared constants, _resolve(), _fetch_job_output(), re-exports from parsers
   _builds.py       →  6 build tools: list_builds, get_build, get_build_failures, diagnose_build, etc.
+  _console.py      →  1 console stream tool: stream_build_console (optional, requires websockets)
   _logs.py         →  3 log tools: get_build_log, browse_build_logs, tail_build_log
   _status.py       →  6 status/analytics: list_tenants, get_status, get_change_status, find_flaky_jobs, etc.
   _config.py       →  15 config/infra: list_jobs, get_job, get_project, list_nodes, get_freeze_job, etc.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 An [MCP](https://modelcontextprotocol.io/) server for [Zuul CI](https://zuul-ci.org/). Debug build failures by asking questions, not clicking through web UIs.
 
-36 tools (31 read-only + 4 write + 1 LogJuicer), 3 prompt templates, and 3 resources — covering builds, logs, pipelines, jobs, infrastructure, and live status. Supports stdio, SSE, and streamable-http transports. Works with Claude Code, Claude Desktop, Cursor, and any MCP-compatible client.
+37 tools (31 read-only + 4 write + 1 LogJuicer + 1 console stream), 3 prompt templates, and 3 resources — covering builds, logs, pipelines, jobs, infrastructure, and live status. Supports stdio, SSE, and streamable-http transports. Works with Claude Code, Claude Desktop, Cursor, and any MCP-compatible client.
 
 ```
 You:   "Why did the latest gate job fail?"
@@ -90,6 +90,7 @@ See [Setup](#setup) for full configuration options including Kerberos and multi-
 | `get_build_log` | Read and search log files. Modes: `summary` (tail + error lines), `full` (paginated), `grep` (regex + context), `start_line`/`end_line` (exact range). Supports `log_name` for any file. Accepts `url` or `uuid`. |
 | `tail_build_log` | **Fastest failure check.** Last N lines of a log (default 50, max 500). More token-efficient than `get_build_log` summary mode. Accepts `url` or `uuid`. |
 | `browse_build_logs` | List log directory contents or fetch specific files (inventory, artifacts, must-gather). Max 512KB per file. Accepts `url` or `uuid`. |
+| `stream_build_console` | **Live console from RUNNING builds.** Connects to Zuul WebSocket, returns last N lines (tail). For completed builds, use `tail_build_log`. Optional — requires `pip install mcp-zuul[console]`. |
 
 ### Buildsets
 
@@ -451,7 +452,7 @@ uv run mypy src/mcp_zuul/
 docker build -t mcp-zuul .
 ```
 
-**Architecture:** Multi-module package in `src/mcp_zuul/` — `config.py` (env vars, transport, tool filtering, read-only mode), `auth.py` (Kerberos/SPNEGO), `server.py` (FastMCP + lifespan + tool filtering + write-tool gating), `helpers.py` (API client with GET/POST/DELETE, URL parsing, log streaming), `formatters.py` (token-efficient output), `errors.py` (uniform error handling), `tools.py` (36 tools), `prompts.py` (3 prompts), `resources.py` (3 resources). See `CLAUDE.md` for full architecture description.
+**Architecture:** Multi-module package in `src/mcp_zuul/` — `config.py` (env vars, transport, tool filtering, read-only mode), `auth.py` (Kerberos/SPNEGO), `server.py` (FastMCP + lifespan + tool filtering + write-tool gating), `helpers.py` (API client with GET/POST/DELETE, URL parsing, log streaming), `formatters.py` (token-efficient output), `errors.py` (uniform error handling), `tools.py` (37 tools), `prompts.py` (3 prompts), `resources.py` (3 resources). See `CLAUDE.md` for full architecture description.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 kerberos = ["gssapi>=1.8.0"]
+console = ["websockets>=14.0"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
@@ -93,5 +94,9 @@ check_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "gssapi.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "websockets.*"
 ignore_missing_imports = true
 

--- a/src/mcp_zuul/tools/__init__.py
+++ b/src/mcp_zuul/tools/__init__.py
@@ -1,4 +1,4 @@
-"""Zuul MCP tool implementations - 36 tools (31 read-only + 4 write + 1 LogJuicer)."""
+"""Zuul MCP tool implementations - 37 tools (31 read-only + 4 write + 1 LogJuicer + 1 console stream)."""
 
 # Re-export symbols used by prompts.py and tests
 # Re-export all tool functions for backward compatibility (tests import from mcp_zuul.tools)
@@ -37,6 +37,7 @@ from ._config import (
     list_projects,
     list_semaphores,
 )
+from ._console import stream_build_console
 from ._logjuicer import get_build_anomalies
 from ._logs import browse_build_logs, get_build_log, tail_build_log
 from ._status import (
@@ -94,5 +95,6 @@ __all__ = [
     "list_projects",
     "list_semaphores",
     "list_tenants",
+    "stream_build_console",
     "tail_build_log",
 ]

--- a/src/mcp_zuul/tools/_common.py
+++ b/src/mcp_zuul/tools/_common.py
@@ -108,7 +108,10 @@ def _no_log_url_error(build: dict, uuid: str) -> str:
         )
         if detail:
             msg += f" Error detail: {detail}"
-        msg += " Use get_change_status for live progress or wait for the build to complete."
+        msg += (
+            " Use stream_build_console for live output, "
+            "get_change_status for progress, or wait for the build to complete."
+        )
         return error(msg)
     return error(
         f"No log_url for build {uuid} (result: {result}). "

--- a/src/mcp_zuul/tools/_console.py
+++ b/src/mcp_zuul/tools/_console.py
@@ -1,0 +1,169 @@
+"""Live console streaming from running builds (optional, requires websockets)."""
+
+import asyncio
+import collections
+import json
+import ssl
+
+from mcp.server.fastmcp import Context
+
+from ..errors import handle_errors
+from ..helpers import app, error, safepath, strip_ansi
+from ..server import mcp
+from ._common import _READ_ONLY, _resolve
+
+
+def _import_websockets():
+    """Lazy import of websockets library."""
+    import websockets
+
+    return websockets
+
+
+@mcp.tool(title="Stream Build Console", annotations=_READ_ONLY)
+@handle_errors
+async def stream_build_console(
+    ctx: Context,
+    uuid: str = "",
+    tenant: str = "",
+    url: str = "",
+    lines: int = 100,
+    timeout: int = 10,
+) -> str:
+    """Read live console output from a RUNNING build.
+
+    Connects to Zuul's WebSocket console-stream endpoint and captures
+    output for ``timeout`` seconds, returning the last ``lines`` lines
+    (tail behavior). This tool is for RUNNING builds only. For completed
+    builds, use tail_build_log or get_build_log instead.
+
+    Optional — requires ``pip install mcp-zuul[console]``.
+
+    Args:
+        uuid: Build UUID (from get_change_status)
+        tenant: Tenant name (uses default if empty)
+        url: Zuul build URL (alternative to uuid + tenant)
+        lines: Number of lines to return from the end (default 100, max 500)
+        timeout: Seconds to buffer before returning (default 10, max 30)
+    """
+    build_uuid, t = _resolve(ctx, uuid, tenant, url, "build")
+    lines = min(max(lines, 1), 500)
+    timeout = min(max(timeout, 3), 30)
+
+    try:
+        websockets = _import_websockets()
+    except ImportError:
+        return error(
+            "websockets library not installed. Install with: pip install mcp-zuul[console]"
+        )
+
+    a = app(ctx)
+
+    # Build WebSocket URL from API base URL
+    base = a.config.base_url
+    if base.startswith("https://"):
+        ws_url = "wss://" + base[len("https://") :]
+    elif base.startswith("http://"):
+        ws_url = "ws://" + base[len("http://") :]
+    else:
+        return error(f"Cannot build WebSocket URL from base: {base}")
+    ws_url = f"{ws_url}/api/tenant/{safepath(t)}/console-stream"
+
+    # SSL context for wss:// connections.
+    # websockets requires ssl=True (default context) or an explicit SSLContext
+    # for wss:// URIs — ssl=None is rejected as incompatible.
+    ssl_ctx: ssl.SSLContext | bool | None = None
+    if ws_url.startswith("wss://"):
+        if a.config.verify_ssl:
+            ssl_ctx = True  # use ssl.create_default_context()
+        else:
+            ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_ctx.check_hostname = False
+            ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    # First message: uuid + logfile (required by Zuul) + optional JWT token
+    init_msg: dict = {"uuid": build_uuid, "logfile": "console.log"}
+    if a.config.auth_token:
+        init_msg["token"] = a.config.auth_token
+
+    try:
+        async with websockets.connect(
+            ws_url,
+            ssl=ssl_ctx,
+            open_timeout=10,
+            close_timeout=5,
+        ) as ws:
+            await ws.send(json.dumps(init_msg))
+
+            buffer: collections.deque[str] = collections.deque(maxlen=lines)
+            total_lines = 0
+            pending = ""  # accumulates partial line across chunk boundaries
+            try:
+                async with asyncio.timeout(timeout):
+                    async for message in ws:
+                        text = (
+                            message
+                            if isinstance(message, str)
+                            else message.decode("utf-8", errors="replace")
+                        )
+                        # Reassemble lines across chunk boundaries: prepend
+                        # any leftover from the previous chunk, split on \n,
+                        # and keep the last fragment as the new pending.
+                        text = pending + text
+                        parts = text.split("\n")
+                        pending = parts.pop()  # last element: partial or ""
+                        for line in parts:
+                            if line:
+                                buffer.append(strip_ansi(line))
+                                total_lines += 1
+            except TimeoutError:
+                pass  # Expected — we buffer for `timeout` seconds
+            # Flush any trailing partial line
+            if pending:
+                buffer.append(strip_ansi(pending))
+                total_lines += 1
+
+            if not buffer:
+                return error(
+                    f"No console output received for build {build_uuid}. "
+                    "The build may have completed or the executor is unreachable."
+                )
+
+            return json.dumps(
+                {
+                    "build_uuid": build_uuid,
+                    "tenant": t,
+                    "total_lines_received": total_lines,
+                    "lines_returned": len(buffer),
+                    "tail": total_lines > len(buffer),
+                    "timeout_seconds": timeout,
+                    "console": "\n".join(buffer),
+                }
+            )
+
+    except websockets.InvalidStatus as e:
+        code = getattr(getattr(e, "response", None), "status_code", 0)
+        if code == 403:
+            return error(
+                "WebSocket auth failed (403). "
+                "Check auth token (ZUUL_AUTH_TOKEN) or tenant auth configuration."
+            )
+        if code == 404:
+            return error(
+                f"Console stream not available for build {build_uuid}. "
+                "Build may have completed — use tail_build_log instead."
+            )
+        return error(f"WebSocket connection failed: HTTP {code}")
+    except websockets.ConnectionClosedError as e:
+        rcvd = getattr(e, "rcvd", None)
+        code = getattr(rcvd, "code", 0)
+        reason = getattr(rcvd, "reason", "")
+        if code == 4000:
+            return error(f"Console stream rejected (4000): {reason}")
+        if code == 4011:
+            return error(f"Console stream error (4011): {reason}")
+        return error(f"Console stream connection closed: code={code} {reason}".strip())
+    except TimeoutError:
+        return error("Console stream connection timed out")
+    except (ConnectionRefusedError, OSError) as e:
+        return error(f"Cannot connect to console stream: {e}")

--- a/tests/test_tools_console.py
+++ b/tests/test_tools_console.py
@@ -1,0 +1,698 @@
+"""Tests for stream_build_console tool."""
+
+import asyncio
+import json
+import ssl
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class _FakeClose:
+    """Simulate a websockets Close frame."""
+
+    def __init__(self, code: int, reason: str = ""):
+        self.code = code
+        self.reason = reason
+
+
+def _make_ws(messages: list[str], *, block: bool = False) -> AsyncMock:
+    """Create a mock WebSocket that yields messages.
+
+    With block=False (default), the iterator ends after messages — fast tests.
+    With block=True, blocks after messages until timeout fires — tests timeout behavior.
+    """
+    ws = AsyncMock()
+    ws.send = AsyncMock()
+
+    async def _aiter() -> AsyncIterator[str]:
+        for m in messages:
+            yield m
+        if block:
+            await asyncio.sleep(999)
+
+    ws.__aenter__ = AsyncMock(return_value=ws)
+    ws.__aexit__ = AsyncMock(return_value=False)
+    ws.__aiter__ = lambda self: _aiter()
+    return ws
+
+
+def _mock_ws_module(connect_rv=None, connect_side_effect=None):
+    """Build a mock websockets module with exception classes."""
+    m = MagicMock()
+    m.InvalidStatus = type("InvalidStatus", (Exception,), {})
+    m.ConnectionClosedError = type("ConnectionClosedError", (Exception,), {})
+    if connect_side_effect:
+        m.connect = MagicMock(side_effect=connect_side_effect)
+    elif connect_rv is not None:
+        m.connect = MagicMock(return_value=connect_rv)
+    return m
+
+
+class TestStreamBuildConsole:
+    """Tests for stream_build_console tool."""
+
+    async def test_missing_dependency(self, mock_ctx):
+        """When websockets is not installed, return clear install instructions."""
+        import sys
+
+        original_import = (
+            __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+        )
+
+        def _fail_websockets(name, *args, **kwargs):
+            if name == "websockets":
+                raise ImportError("No module named 'websockets'")
+            return original_import(name, *args, **kwargs)
+
+        # Clear sys.modules cache so the lazy import actually calls __import__
+        saved = sys.modules.pop("websockets", None)
+        try:
+            with patch("builtins.__import__", side_effect=_fail_websockets):
+                from mcp_zuul.tools._console import stream_build_console
+
+                result = json.loads(
+                    await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant")
+                )
+                assert "error" in result
+                assert "websockets" in result["error"]
+                assert "mcp-zuul[console]" in result["error"]
+        finally:
+            if saved is not None:
+                sys.modules["websockets"] = saved
+
+    async def test_basic_streaming(self, mock_ctx):
+        """Basic: mock WS sends 3 lines, all returned."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(
+            [
+                "TASK [setup : install] ***\n",
+                "ok: [controller-0]\n",
+                "TASK [validate : check] ***\n",
+            ]
+        )
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "console" in result
+        assert result["lines_returned"] == 3
+        assert result["total_lines_received"] == 3
+        assert result["build_uuid"] == "abc123"
+        assert result["tenant"] == "test-tenant"
+        assert "TASK [setup : install]" in result["console"]
+        assert "TASK [validate : check]" in result["console"]
+
+    async def test_tail_behavior(self, mock_ctx):
+        """When more lines received than requested, only tail is returned."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        messages = [f"line {i}\n" for i in range(200)]
+        ws = _make_ws(messages)
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(
+                    mock_ctx, uuid="abc123", tenant="test-tenant", lines=50, timeout=3
+                )
+            )
+
+        assert result["lines_returned"] == 50
+        assert result["total_lines_received"] == 200
+        assert result["tail"] is True
+        # Should contain the LAST 50 lines (150-199)
+        assert "line 199" in result["console"]
+        assert "line 150" in result["console"]
+        assert "line 149" not in result["console"]
+
+    async def test_empty_stream(self, mock_ctx):
+        """When no messages received, return error."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws([])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "no console output" in result["error"].lower()
+
+    async def test_auth_token_forwarded(self, mock_ctx):
+        """When config has auth_token, it's included in the first WS message."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mock_ctx.request_context.lifespan_context.config.auth_token = "my-jwt-token"
+        ws = _make_ws(["some output\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+
+        ws.send.assert_called_once()
+        sent = json.loads(ws.send.call_args[0][0])
+        assert sent["token"] == "my-jwt-token"
+        assert sent["uuid"] == "abc123"
+        assert sent["logfile"] == "console.log"
+
+        mock_ctx.request_context.lifespan_context.config.auth_token = None
+
+    async def test_no_auth_token_omitted(self, mock_ctx):
+        """When no auth_token, the token field is not in the first message."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["output\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+
+        sent = json.loads(ws.send.call_args[0][0])
+        assert "token" not in sent
+
+    async def test_http_403_on_upgrade(self, mock_ctx):
+        """InvalidStatus with 403 -> auth failed error."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module()
+        exc = mod.InvalidStatus()
+        exc.response = MagicMock()
+        exc.response.status_code = 403
+        mod.connect = MagicMock(side_effect=exc)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "403" in result["error"] or "auth" in result["error"].lower()
+
+    async def test_http_404_on_upgrade(self, mock_ctx):
+        """InvalidStatus with 404 -> build completed or not available."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module()
+        exc = mod.InvalidStatus()
+        exc.response = MagicMock()
+        exc.response.status_code = 404
+        mod.connect = MagicMock(side_effect=exc)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "completed" in result["error"].lower() or "not available" in result["error"].lower()
+
+    async def test_connection_closed_4000(self, mock_ctx):
+        """ConnectionClosedError with code 4000 -> validation/auth error with reason."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module()
+        exc = mod.ConnectionClosedError()
+        exc.rcvd = _FakeClose(4000, "'uuid' missing from request payload")
+
+        ws = AsyncMock()
+        ws.__aenter__ = AsyncMock(return_value=ws)
+        ws.__aexit__ = AsyncMock(return_value=False)
+        ws.send = AsyncMock()
+
+        async def _raise_on_iter() -> AsyncIterator[str]:
+            raise exc
+            yield  # make it a generator
+
+        ws.__aiter__ = lambda self: _raise_on_iter()
+        mod.connect = MagicMock(return_value=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "4000" in result["error"]
+        assert "missing" in result["error"].lower()
+
+    async def test_connection_closed_4011(self, mock_ctx):
+        """ConnectionClosedError with code 4011 -> streaming error."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module()
+        exc = mod.ConnectionClosedError()
+        exc.rcvd = _FakeClose(4011, "streaming error")
+
+        ws = AsyncMock()
+        ws.__aenter__ = AsyncMock(return_value=ws)
+        ws.__aexit__ = AsyncMock(return_value=False)
+        ws.send = AsyncMock()
+
+        async def _raise_on_iter() -> AsyncIterator[str]:
+            raise exc
+            yield  # make it a generator
+
+        ws.__aiter__ = lambda self: _raise_on_iter()
+        mod.connect = MagicMock(return_value=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "4011" in result["error"] or "streaming" in result["error"].lower()
+
+    async def test_connection_closed_mid_stream(self, mock_ctx):
+        """ConnectionClosedError after some data: buffered lines are lost, error returned."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module()
+        exc = mod.ConnectionClosedError()
+        exc.rcvd = _FakeClose(4011, "executor died")
+
+        ws = AsyncMock()
+        ws.__aenter__ = AsyncMock(return_value=ws)
+        ws.__aexit__ = AsyncMock(return_value=False)
+        ws.send = AsyncMock()
+
+        async def _yield_then_die() -> AsyncIterator[str]:
+            yield "line 1\n"
+            yield "line 2\n"
+            raise exc
+
+        ws.__aiter__ = lambda self: _yield_then_die()
+        mod.connect = MagicMock(return_value=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        # ConnectionClosedError propagates past the buffer -> error, not partial data
+        assert "error" in result
+        assert "4011" in result["error"]
+
+    async def test_connection_refused(self, mock_ctx):
+        """ConnectionRefusedError -> clear error message."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module(connect_side_effect=ConnectionRefusedError("Connection refused"))
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "connect" in result["error"].lower() or "refused" in result["error"].lower()
+
+    async def test_ansi_stripping(self, mock_ctx):
+        """ANSI escape codes are stripped from console output."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["\x1b[32mok\x1b[0m: [controller-0]\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "\x1b" not in result["console"]
+        assert "ok: [controller-0]" in result["console"]
+
+    async def test_bytes_message_decoded(self, mock_ctx):
+        """Binary WebSocket frames are decoded as UTF-8, not repr'd."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = AsyncMock()
+        ws.__aenter__ = AsyncMock(return_value=ws)
+        ws.__aexit__ = AsyncMock(return_value=False)
+        ws.send = AsyncMock()
+
+        async def _yield_bytes() -> AsyncIterator[bytes]:
+            yield b"binary line\n"
+
+        ws.__aiter__ = lambda self: _yield_bytes()
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert result["lines_returned"] == 1
+        assert "binary line" in result["console"]
+        assert "b'" not in result["console"]  # Not repr'd
+
+    async def test_lines_clamped_low(self, mock_ctx):
+        """lines=0 is clamped to 1."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["line1\n", "line2\n", "line3\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(
+                    mock_ctx, uuid="abc123", tenant="test-tenant", lines=0, timeout=3
+                )
+            )
+
+        assert result["lines_returned"] == 1
+        assert result["tail"] is True
+
+    async def test_lines_clamped_high(self, mock_ctx):
+        """lines=999 is clamped to 500."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["line\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(
+                    mock_ctx, uuid="abc123", tenant="test-tenant", lines=999, timeout=3
+                )
+            )
+
+        assert result["lines_returned"] == 1
+        assert result["tail"] is False
+
+    async def test_ws_url_construction(self, mock_ctx):
+        """WebSocket URL is built correctly from config.base_url."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["output\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+
+        ws_url = mod.connect.call_args[0][0]
+        assert ws_url == "wss://zuul.example.com/api/tenant/test-tenant/console-stream"
+
+    async def test_ws_url_http_to_ws(self, mock_ctx):
+        """http:// base URL maps to ws:// WebSocket URL."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mock_ctx.request_context.lifespan_context.config.base_url = "http://zuul.local"
+        ws = _make_ws(["output\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+
+        ws_url = mod.connect.call_args[0][0]
+        assert ws_url.startswith("ws://")
+        assert ws_url == "ws://zuul.local/api/tenant/test-tenant/console-stream"
+        # ws:// should NOT have SSL context
+        assert mod.connect.call_args[1].get("ssl") is None
+
+        mock_ctx.request_context.lifespan_context.config.base_url = "https://zuul.example.com"
+
+    async def test_ssl_context_verify_false(self, mock_ctx):
+        """When verify_ssl=False, SSL context disables cert verification."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mock_ctx.request_context.lifespan_context.config.verify_ssl = False
+        ws = _make_ws(["output\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+
+        call_kwargs = mod.connect.call_args[1]
+        ssl_ctx = call_kwargs.get("ssl")
+        assert ssl_ctx is not None
+        assert ssl_ctx.check_hostname is False
+        assert ssl_ctx.verify_mode == ssl.CERT_NONE
+
+        mock_ctx.request_context.lifespan_context.config.verify_ssl = True
+
+    async def test_ssl_context_verify_true(self, mock_ctx):
+        """When verify_ssl=True (default), ssl=True is passed for default context."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["output\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+
+        call_kwargs = mod.connect.call_args[1]
+        assert call_kwargs.get("ssl") is True
+
+    async def test_uuid_required(self, mock_ctx):
+        """When no uuid and no url, return error."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        result = json.loads(await stream_build_console(mock_ctx, tenant="test-tenant", timeout=3))
+        assert "error" in result
+        assert "required" in result["error"].lower()
+
+    async def test_url_param_parses_build(self, mock_ctx):
+        """url parameter extracts UUID and tenant from Zuul build URL."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["output\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(
+                    mock_ctx,
+                    url="https://zuul.example.com/t/my-tenant/build/deadbeef-1234",
+                    timeout=3,
+                )
+            )
+
+        assert result["build_uuid"] == "deadbeef-1234"
+        assert result["tenant"] == "my-tenant"
+        # Verify WS URL uses parsed tenant
+        ws_url = mod.connect.call_args[0][0]
+        assert "/tenant/my-tenant/" in ws_url
+
+    async def test_multiline_messages(self, mock_ctx):
+        """A single WS message containing multiple lines is split correctly."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["line1\nline2\nline3\n"])
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert result["total_lines_received"] == 3
+        assert result["lines_returned"] == 3
+        assert "line1" in result["console"]
+        assert "line3" in result["console"]
+
+    async def test_normal_close_returns_buffered(self, mock_ctx):
+        """When server sends close(1000), buffered lines are returned."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = AsyncMock()
+        ws.__aenter__ = AsyncMock(return_value=ws)
+        ws.__aexit__ = AsyncMock(return_value=False)
+        ws.send = AsyncMock()
+
+        async def _iter_then_close() -> AsyncIterator[str]:
+            yield "task running\n"
+            yield "task complete\n"
+
+        ws.__aiter__ = lambda self: _iter_then_close()
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert result["lines_returned"] == 2
+        assert "task complete" in result["console"]
+
+    async def test_tenant_path_traversal_rejected(self, mock_ctx):
+        """Tenant with '..' is rejected by safepath before WebSocket connect."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module()
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="../admin", timeout=3)
+            )
+        assert "error" in result
+        assert "invalid" in result["error"].lower() or "path" in result["error"].lower()
+
+    async def test_os_error_from_connect(self, mock_ctx):
+        """Generic OSError (e.g. network unreachable) during connect is handled."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module(connect_side_effect=OSError("Network is unreachable"))
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "connect" in result["error"].lower() or "unreachable" in result["error"].lower()
+
+    async def test_timeout_stops_reading(self, mock_ctx):
+        """The timeout fires to stop reading from a live (blocking) stream."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = _make_ws(["live output\n"], block=True)
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert result["lines_returned"] == 1
+        assert result["timeout_seconds"] == 3
+        assert "live output" in result["console"]
+
+    async def test_invalid_base_url_scheme(self, mock_ctx):
+        """Non-http/https base URL returns clear error."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mock_ctx.request_context.lifespan_context.config.base_url = "ftp://zuul.example.com"
+        mod = _mock_ws_module()
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "websocket url" in result["error"].lower() or "ftp" in result["error"].lower()
+
+        mock_ctx.request_context.lifespan_context.config.base_url = "https://zuul.example.com"
+
+    async def test_generic_http_error_on_upgrade(self, mock_ctx):
+        """InvalidStatus with unexpected code (e.g. 500) returns generic error."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module()
+        exc = mod.InvalidStatus()
+        exc.response = MagicMock()
+        exc.response.status_code = 500
+        mod.connect = MagicMock(side_effect=exc)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "500" in result["error"]
+
+    async def test_generic_connection_close_code(self, mock_ctx):
+        """ConnectionClosedError with unexpected code returns generic message."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module()
+        exc = mod.ConnectionClosedError()
+        exc.rcvd = _FakeClose(1006, "abnormal closure")
+
+        ws = AsyncMock()
+        ws.__aenter__ = AsyncMock(return_value=ws)
+        ws.__aexit__ = AsyncMock(return_value=False)
+        ws.send = AsyncMock()
+
+        async def _raise_on_iter() -> AsyncIterator[str]:
+            raise exc
+            yield  # make it a generator
+
+        ws.__aiter__ = lambda self: _raise_on_iter()
+        mod.connect = MagicMock(return_value=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "1006" in result["error"]
+        assert "abnormal" in result["error"].lower()
+
+    async def test_partial_lines_reassembled(self, mock_ctx):
+        """Chunks splitting mid-line are reassembled correctly."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        # Simulate Zuul sending 4096-byte chunks that split mid-line
+        ws = AsyncMock()
+        ws.__aenter__ = AsyncMock(return_value=ws)
+        ws.__aexit__ = AsyncMock(return_value=False)
+        ws.send = AsyncMock()
+
+        async def _chunked() -> AsyncIterator[str]:
+            yield "TASK [setup : inst"  # chunk ends mid-word
+            yield "all_packages] ***\nok: [controller-0]\n"  # completes previous + new line
+            yield "TASK [val"
+            yield "idate] ***\n"
+
+        ws.__aiter__ = lambda self: _chunked()
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert result["total_lines_received"] == 3
+        assert result["lines_returned"] == 3
+        # Lines should be properly reassembled, not split at chunk boundaries
+        lines = result["console"].split("\n")
+        assert "TASK [setup : install_packages] ***" in lines
+        assert "ok: [controller-0]" in lines
+        assert "TASK [validate] ***" in lines
+
+    async def test_trailing_partial_line_flushed(self, mock_ctx):
+        """A partial line at the end of stream (no trailing newline) is included."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        ws = AsyncMock()
+        ws.__aenter__ = AsyncMock(return_value=ws)
+        ws.__aexit__ = AsyncMock(return_value=False)
+        ws.send = AsyncMock()
+
+        async def _no_trailing_newline() -> AsyncIterator[str]:
+            yield "line1\nline2_no_newline"
+
+        ws.__aiter__ = lambda self: _no_trailing_newline()
+        mod = _mock_ws_module(connect_rv=ws)
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert result["total_lines_received"] == 2
+        assert "line2_no_newline" in result["console"]
+
+    async def test_open_timeout_produces_clear_error(self, mock_ctx):
+        """open_timeout failure returns timeout-specific error, not generic OSError."""
+        from mcp_zuul.tools._console import stream_build_console
+
+        mod = _mock_ws_module(connect_side_effect=TimeoutError("timed out"))
+
+        with patch("mcp_zuul.tools._console._import_websockets", return_value=mod):
+            result = json.loads(
+                await stream_build_console(mock_ctx, uuid="abc123", tenant="test-tenant", timeout=3)
+            )
+
+        assert "error" in result
+        assert "timed out" in result["error"].lower()


### PR DESCRIPTION
## Summary

- New tool: `stream_build_console` — reads live console output from RUNNING builds via Zuul's WebSocket `console-stream` endpoint
- Optional dependency (`websockets>=14.0`) via `[console]` extra with lazy import
- Tail behavior using `deque(maxlen)` circular buffer — buffers for N seconds, returns last M lines
- Line reassembly across chunk boundaries (Zuul sends raw 4KB chunks from finger protocol)
- Auth via JWT token in WebSocket message body (verified against upstream Zuul source)

## Details

- 33 tests, 99% coverage on `_console.py`
- Live-tested against `zuul.opendev.org` — 16,501 lines streamed in 5 seconds
- Updated `_no_log_url_error` to mention the new tool for IN_PROGRESS builds
- Bugs found and fixed during adversarial review:
  - `ssl=None` rejected by websockets 16 for `wss://` URIs (caught by live testing)
  - `str(bytes)` produces repr instead of decoded text
  - Chunk boundaries splitting lines into garbled fragments
  - `TimeoutError` swallowed by `OSError` handler

## Test plan

- [x] 33 unit tests covering all code paths (error, auth, SSL, tail, line reassembly, close codes)
- [x] Full regression suite: 674 tests pass
- [x] Lint: ruff check + ruff format + mypy clean
- [x] Live tested against zuul.opendev.org (running build, completed build, bogus UUID, wrong tenant, URL param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)