### PR TITLE
[DOCS] Update CLI example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,12 @@ pip install mcp-zuul[kerberos]    # or: uvx --with "mcp-zuul[kerberos]" mcp-zuul
 
 Via CLI:
 ```bash
-claude mcp add -s user \
+claude mcp add -s user zuul-internal \
                -e ZUUL_URL=https://internal-zuul.example.com/zuul \
                -e ZUUL_DEFAULT_TENANT=my-tenant \
                -e ZUUL_USE_KERBEROS=true \
                -e ZUUL_VERIFY_SSL=false \
-               zuul -- uvx --with "mcp-zuul[kerberos]" mcp-zuul
+               -- uvx --with "mcp-zuul[kerberos]" mcp-zuul
 ```
 
 Or via JSON config:


### PR DESCRIPTION
The currently given example would produce an error "Invalid environment variable format" when trying
to add new MCP server to Claude, because the server name must appear *before* the environment variables, contrary to what the Claude's CLI help show!

There are several bugs reported for that in Claude Code repository e.g. https://github.com/anthropics/claude-code/issues/46121 however they seem not to care about this one...
