### PR TITLE
[DOCS] Update CLI example in README.md (part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ claude mcp add zuul -- uvx mcp-zuul
 ```
 Then set the required env var:
 ```bash
-claude mcp add -e ZUUL_URL=https://softwarefactory-project.io/zuul \
+claude mcp add zuul \
+               -e ZUUL_URL=https://softwarefactory-project.io/zuul \
                -e ZUUL_DEFAULT_TENANT=rdoproject.org \
-               zuul -- uvx mcp-zuul
+               -- uvx mcp-zuul
 ```
 
 **pip**:
@@ -200,9 +201,10 @@ All clients use the same JSON structure. Add to your client's MCP config file:
 
 Or via CLI:
 ```bash
-claude mcp add -e ZUUL_URL=https://softwarefactory-project.io/zuul \
+claude mcp add zuul \
+               -e ZUUL_URL=https://softwarefactory-project.io/zuul \
                -e ZUUL_DEFAULT_TENANT=rdoproject.org \
-               zuul -- uvx mcp-zuul
+               -- uvx mcp-zuul
 ```
 
 ### Environment variables


### PR DESCRIPTION
The currently given example would produce an error "Invalid environment variable format" when trying
to add new MCP server to Claude, because the server name must appear *before* the environment variables, contrary to what the Claude's CLI help show!

There are several bugs reported for that in Claude Code repository e.g. https://github.com/anthropics/claude-code/issues/46121 however they seem not to care about this one...