### PR TITLE
fix: restore CI lint and formatting

### DIFF
--- a/src/mcp_zuul/classifier.py
+++ b/src/mcp_zuul/classifier.py
@@ -188,7 +188,9 @@ def _classify_tasks(
     if log_context:
         all_text += " " + _collect_log_text(log_context)
     if not all_text:
-        return Classification(category="UNKNOWN", reason="No error text", confidence="low", retryable=False)
+        return Classification(
+            category="UNKNOWN", reason="No error text", confidence="low", retryable=False
+        )
 
     infra_reason: str | None = None
     for pattern, reason in _INFRA_PATTERNS:
@@ -216,7 +218,9 @@ def _classify_tasks(
             confidence="high",
             retryable=True,
         )
-    return Classification(category="UNKNOWN", reason="No pattern matched", confidence="low", retryable=False)
+    return Classification(
+        category="UNKNOWN", reason="No pattern matched", confidence="low", retryable=False
+    )
 
 
 def classify_failure(

--- a/src/mcp_zuul/tools/_builds.py
+++ b/src/mcp_zuul/tools/_builds.py
@@ -522,10 +522,7 @@ async def diagnose_build(
             out["reflection"] = reflection
         if not failed_tasks and log_context:
             matches = [
-                line["text"]
-                for block in log_context[:2]
-                for line in block
-                if line.get("match")
+                line["text"] for block in log_context[:2] for line in block if line.get("match")
             ]
             if matches:
                 out["error_snippet"] = matches[0][:300]

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -975,7 +975,7 @@ class TestParsePlaybooksPhaseField:
                 ],
             },
         ]
-        playbooks, failed_tasks = parse_playbooks(data)
+        _playbooks, failed_tasks = parse_playbooks(data)
         assert len(failed_tasks) == 2
         assert failed_tasks[0]["phase"] == "run"
         assert failed_tasks[1]["phase"] == "post"

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -142,7 +142,6 @@ class TestApiPostNonJsonResponse:
         )
         assert result == {}
 
-
     @respx.mock
     async def test_boolean_response_normalized_to_dict(self, mock_ctx):
         """Zuul write endpoints may return bare `true`; must not break **result."""
@@ -160,9 +159,9 @@ class TestApiPostNonJsonResponse:
     @respx.mock
     async def test_integer_response_normalized_to_dict(self, mock_ctx):
         """Zuul write endpoints may return a bare integer (e.g. autohold ID)."""
-        respx.post("https://zuul.example.com/api/tenant/test-tenant/project/org/repo/autohold").mock(
-            return_value=httpx.Response(200, json=42)
-        )
+        respx.post(
+            "https://zuul.example.com/api/tenant/test-tenant/project/org/repo/autohold"
+        ).mock(return_value=httpx.Response(200, json=42))
         result = await api_post(
             mock_ctx,
             "/tenant/test-tenant/project/org/repo/autohold",

--- a/tests/test_tools_logs.py
+++ b/tests/test_tools_logs.py
@@ -624,7 +624,9 @@ class TestBrowseBuildLogs404Guidance:
             return_value=httpx.Response(200, json=build)
         )
         respx.get(f"{build['log_url']}some-other-path/").mock(return_value=httpx.Response(404))
-        result = json.loads(await browse_build_logs(mock_ctx, "build-uuid-1", path="some-other-path/"))
+        result = json.loads(
+            await browse_build_logs(mock_ctx, "build-uuid-1", path="some-other-path/")
+        )
         assert "error" in result
         assert "diagnose_build" not in result["error"]
 

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -130,7 +130,6 @@ class TestAutoholdCreate:
         assert result["job"] == "deploy-job"
         assert result["id"] == "42"
 
-
     @respx.mock
     async def test_handles_boolean_response(self, mock_ctx):
         """Zuul autohold API may return bare `true` instead of a JSON object."""
@@ -138,9 +137,7 @@ class TestAutoholdCreate:
             "https://zuul.example.com/api/tenant/test-tenant/project/org%2Frepo/autohold"
         ).mock(return_value=httpx.Response(200, json=True))
         result = json.loads(
-            await autohold_create(
-                mock_ctx, project="org/repo", job="deploy-job", reason="debug"
-            )
+            await autohold_create(mock_ctx, project="org/repo", job="deploy-job", reason="debug")
         )
         assert result["status"] == "created"
         assert result["job"] == "deploy-job"
@@ -150,9 +147,7 @@ class TestAutoholdCreate:
         route = respx.post(
             "https://zuul.example.com/api/tenant/test-tenant/project/org%2Frepo/autohold"
         ).mock(return_value=httpx.Response(200, json=True))
-        await autohold_create(
-            mock_ctx, project="org/repo", job="deploy-job", change="12345"
-        )
+        await autohold_create(mock_ctx, project="org/repo", job="deploy-job", change="12345")
         body = json.loads(route.calls[0].request.content)
         assert body["change"] == "12345"
         assert body["job"] == "deploy-job"
@@ -164,9 +159,7 @@ class TestAutoholdCreate:
         route = respx.post(
             "https://zuul.example.com/api/tenant/test-tenant/project/org%2Frepo/autohold"
         ).mock(return_value=httpx.Response(200, json=True))
-        await autohold_create(
-            mock_ctx, project="org/repo", job="deploy-job", ref="refs/heads/main"
-        )
+        await autohold_create(mock_ctx, project="org/repo", job="deploy-job", ref="refs/heads/main")
         body = json.loads(route.calls[0].request.content)
         assert body["ref_filter"] == "refs/heads/main"
 


### PR DESCRIPTION
## What changed

- Mark the intentionally unused `parse_playbooks` return value as `_playbooks`.
- Apply Ruff formatting to files whose failures were masked by the initial lint error.
- Include the formatting correction introduced by the latest `main` commit.

## Root cause

CI stopped at `RUF059` in `tests/test_classifier.py`, so the subsequent Ruff format step never ran. Once that lint error was fixed, five pre-existing formatting failures became visible.

## Impact

This is a lint/format-only correction. Production behavior is unchanged.

## Validation

- Ruff lint: passed
- Ruff format check: passed
- Mypy: passed
- Dependency audit: no known vulnerabilities
- Python 3.11: 880 tests passed
- Python 3.12: 880 tests passed
- Python 3.13: 880 tests passed
- Coverage: 94.73% (minimum: 85%)
