### PR TITLE
chore: flagship best-practices hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v5.4.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.1
         with:
           version: "latest"
           enable-cache: true
@@ -36,7 +36,7 @@ jobs:
         run: uv run pytest tests/ -v --cov=mcp_zuul --cov-fail-under=85 --cov-report=term-missing --cov-report=xml
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.xml
           fail_ci_if_error: false
@@ -47,8 +47,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v5.4.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.1
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest"
           enable-cache: true
@@ -47,8 +47,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v5.4.1
         with:
           version: "latest"
           enable-cache: true
@@ -36,7 +36,7 @@ jobs:
         run: uv run pytest tests/ -v --cov=mcp_zuul --cov-fail-under=85 --cov-report=term-missing --cov-report=xml
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           files: coverage.xml
           fail_ci_if_error: false
@@ -47,8 +47,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v5.4.1
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -16,8 +18,8 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.1
         with:
           version: "latest"
           enable-cache: true
@@ -33,34 +35,32 @@ jobs:
   build:
     needs: verify
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v7
-
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff9f9c6cc0d0f96fce4 # v3.6.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@902fa8ec7d6ecbea8a87b1b2b9f89c4bc2897f54 # v5.7.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
-
       - name: Build and push
-        uses: docker/build-push-action@v7
+        id: push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
           context: .
           push: true
@@ -69,3 +69,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          sbom: true
+          provenance: mode=max
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669b3 # v2.3.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,8 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest"
           enable-cache: true
@@ -38,20 +38,20 @@ jobs:
     outputs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff9f9c6cc0d0f96fce4 # v3.6.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbea8a87b1b2b9f89c4bc2897f54 # v5.7.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -60,7 +60,7 @@ jobs:
             type=raw,value=latest
       - name: Build and push
         id: push
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true
@@ -72,7 +72,7 @@ jobs:
           sbom: true
           provenance: mode=max
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669b3 # v2.3.0
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "latest"
       - name: Set up Python
@@ -34,11 +34,11 @@ jobs:
       - name: Build package
         run: uv build
       - name: Publish to PyPI using OIDC
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true
           files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v5.4.1
+        with:
+          version: "latest"
+      - name: Set up Python
+        run: uv python install 3.13
+      - name: Install dependencies
+        run: uv sync --extra dev --python 3.13
+      - name: Verify tag matches package version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG_VER=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          if [ "$TAG" != "$PKG_VER" ]; then
+            echo "Tag $TAG != package version $PKG_VER — aborting"
+            exit 1
+          fi
+      - name: Run tests
+        run: uv run pytest tests/ -v --cov=mcp_zuul --cov-fail-under=85
+      - name: Build package
+        run: uv build
+      - name: Publish to PyPI using OIDC
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          attestations: true
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        with:
+          generate_release_notes: true
+          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags: ["v*"]
 
 permissions:
+  actions: write
   contents: write
   id-token: write
 
@@ -42,3 +43,7 @@ jobs:
         with:
           generate_release_notes: true
           files: dist/*
+      - name: Trigger MCP Registry publish
+        run: gh workflow run publish-registry.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,59 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 1 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          languages: python
+          queries: security-and-quality
+      - uses: github/codeql-action/autobuild@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      - uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+  dependency-review:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5e8a0ca9a283f # v4.6.0
+        with:
+          comment-summary-in-pr: always
+          fail-on-severity: high
+  scorecard:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b08e1e98 # v2.4.1
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+        with:
+          sarif_file: scorecard-results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,13 +19,13 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: github/codeql-action/init@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: python
           queries: security-and-quality
-      - uses: github/codeql-action/autobuild@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
-      - uses: github/codeql-action/analyze@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      - uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
   dependency-review:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -33,8 +33,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5e8a0ca9a283f # v4.6.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           comment-summary-in-pr: always
           fail-on-severity: high
@@ -46,14 +46,14 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b08e1e98 # v2.4.1
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
+      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: scorecard-results.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,20 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libkrb5-3 libgssapi-krb5-2 && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -r -s /bin/false mcp
+    useradd -r -u 10001 -s /bin/false mcp
 
 COPY --from=build /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=build /usr/local/bin/mcp-zuul /usr/local/bin/mcp-zuul
 
 USER mcp
+
+LABEL org.opencontainers.image.title="mcp-zuul" \
+      org.opencontainers.image.description="MCP server for Zuul CI — build failure analysis, log search, pipeline status, and job configuration" \
+      org.opencontainers.image.source="https://github.com/imatza-rh/mcp-zuul" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.documentation="https://imatza-rh.github.io/mcp-zuul/"
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python -c "import mcp_zuul" || exit 1
 
 ENTRYPOINT ["mcp-zuul"]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-.PHONY: help install test lint format typecheck check build clean release
+.PHONY: help install test lint format typecheck check audit ci generate-docs build clean release release-check
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install dev dependencies
 	uv sync --extra dev
 
-test: ## Run tests
-	uv run pytest tests/ -v
+test: ## Run tests with coverage
+	uv run pytest tests/ -v --cov=mcp_zuul --cov-fail-under=85 --cov-report=term-missing
 
 lint: ## Run linter
 	uv run ruff check src/ tests/
@@ -19,10 +19,18 @@ format: ## Auto-format code
 typecheck: ## Run type checker
 	uv run mypy src/mcp_zuul/
 
+audit: ## Audit dependencies for known CVEs
+	uv run pip-audit
+
 docs: ## Serve docs locally (http://127.0.0.1:8001)
 	uvx --with mkdocs-material mkdocs serve -a 127.0.0.1:8001
 
-check: lint typecheck test ## Run all checks (lint + typecheck + test)
+generate-docs: ## Auto-generate docs/tools.md from registered tool metadata
+	uv run python scripts/generate_tool_docs.py
+
+ci: lint typecheck audit test ## Run full CI suite locally
+
+check: ci ## Alias for ci
 
 build: ## Build Docker image
 	docker build -t mcp-zuul .
@@ -35,9 +43,7 @@ release: ## Release a version (make release V=0.5.0 or V=patch)
 	@test -n "$(V)" || (echo "Usage: make release V=<version|patch|minor|major>" && exit 1)
 	./release.sh $(V)
 
-release-check: check ## Dry-run release validation (lint + typecheck + test + format + build)
+release-check: ci ## Dry-run release validation
 	uv run ruff format --check src/ tests/
-	@security find-generic-password -a pypi -s mcp-zuul -w >/dev/null 2>&1 \
-		|| (echo "WARNING: PyPI token not found in keychain (release will fail at publish step)" && exit 1)
 	uv build
 	@echo "Release validation passed. Run 'make release V=<version>' to publish."

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,9 @@ You will receive an acknowledgment within 48 hours and a detailed response withi
 
 | Version | Supported |
 |---------|-----------|
-| 0.3.x   | Yes       |
-| < 0.3   | No        |
+| 0.10.x  | Yes       |
+| 0.9.x   | Yes       |
+| < 0.9   | No        |
 
 ## Security Controls
 
@@ -27,6 +28,9 @@ mcp-zuul implements the following security measures:
 - **Regex timeout**: User-supplied grep patterns run in a thread executor with a 10-second timeout to prevent catastrophic backtracking.
 - **Read-only by default**: Write tools (enqueue, dequeue, autohold) are removed from the server entirely when `ZUUL_READ_ONLY=true` (default). LLMs cannot invoke tools that don't exist.
 - **Input validation**: All user-facing parameters are validated before use. Limits enforced on pagination (max 100), log lines (max 500), and response sizes.
+- **Supply-chain integrity**: Docker images are built with SBOM generation and provenance attestation. PyPI releases use OIDC Trusted Publishing.
+- **Dependency auditing**: `pip-audit` runs in CI on every push and PR.
+- **OpenSSF Scorecard**: Weekly scorecard scans publish results to GitHub Security.
 
 ## Best Practices for Users
 
@@ -35,3 +39,4 @@ mcp-zuul implements the following security measures:
 - Keep `ZUUL_READ_ONLY=true` (default) unless write operations are explicitly needed
 - For Docker, forward tokens without values: `-e ZUUL_AUTH_TOKEN` (inherits from host)
 - Use `ZUUL_ENABLED_TOOLS` to restrict tool exposure to only what's needed
+- Pin container images to a specific digest for reproducible deployments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,9 @@ known-first-party = ["mcp_zuul"]
 
 [tool.mypy]
 python_version = "3.11"
-warn_return_any = true
+warn_return_any = false
 warn_unused_configs = true
-disallow_untyped_defs = true
+disallow_untyped_defs = false
 check_untyped_defs = true
 strict_equality = true
 warn_redundant_casts = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "ruff>=0.9",
     "mypy>=1.14",
     "types-defusedxml>=0.7",
+    "websockets>=14.0",
 ]
 
 [project.scripts]
@@ -50,7 +51,7 @@ Homepage = "https://github.com/imatza-rh/mcp-zuul"
 Documentation = "https://github.com/imatza-rh/mcp-zuul#why-mcp-zuul"
 Repository = "https://github.com/imatza-rh/mcp-zuul"
 Issues = "https://github.com/imatza-rh/mcp-zuul/issues"
-Changelog = "https://github.com/imatza-rh/mcp-zuul/releases"
+Changelog = "https://github.com/imatza-rh/mcp-zuul/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling"]
@@ -69,31 +70,21 @@ line-length = 100
 src = ["src", "tests"]
 
 [tool.ruff.lint]
-select = [
-    "E",    # pycodestyle errors
-    "W",    # pycodestyle warnings
-    "F",    # pyflakes
-    "I",    # isort
-    "UP",   # pyupgrade
-    "B",    # flake8-bugbear
-    "SIM",  # flake8-simplify
-    "TCH",  # flake8-type-checking
-    "RUF",  # ruff-specific
-]
-ignore = [
-    "E501",   # line length (handled by formatter)
-    "SIM108", # ternary operator (readability preference)
-]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "TCH", "RUF"]
+ignore = ["E501", "SIM108"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["mcp_zuul"]
 
 [tool.mypy]
 python_version = "3.11"
-warn_return_any = false
+warn_return_any = true
 warn_unused_configs = true
-disallow_untyped_defs = false
+disallow_untyped_defs = true
 check_untyped_defs = true
+strict_equality = true
+warn_redundant_casts = true
+warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = "gssapi.*"
@@ -102,4 +93,3 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "websockets.*"
 ignore_missing_imports = true
-

--- a/release.sh
+++ b/release.sh
@@ -5,8 +5,8 @@
 #   ./release.sh <version>          # e.g. ./release.sh 0.5.0
 #   ./release.sh patch|minor|major  # auto-bump from current version
 #
-# Steps: validate → bump → commit → push → tag → PyPI → GH release → MCP registry
-# Aborts on any failure. Requires: uv, gh, git, security (macOS keychain).
+# Steps: validate → bump → commit → push → tag → (release.yml handles PyPI + GH release)
+# Aborts on any failure. Requires: uv, gh, git.
 
 set -euo pipefail
 
@@ -61,10 +61,6 @@ BEHIND=$(git rev-list --count HEAD..origin/main)
 
 command -v uv  >/dev/null || die "uv not found"
 command -v gh  >/dev/null || die "gh not found"
-
-# Check PyPI token is accessible
-security find-generic-password -a pypi -s mcp-zuul -w >/dev/null 2>&1 \
-    || die "PyPI token not found in keychain (service: mcp-zuul, account: pypi)"
 
 git tag -l "v${VERSION}" | grep -q . && die "Tag v${VERSION} already exists"
 
@@ -123,34 +119,7 @@ info "Creating tag v${VERSION}"
 
 git tag -a "v${VERSION}" -m "v${VERSION}"
 git push origin "v${VERSION}"
-ok "Tag v${VERSION} pushed (Docker build triggered)"
-
-# ── PyPI ─────────────────────────────────────────────────────────────────────
-
-info "Publishing to PyPI"
-
-rm -rf dist/
-uv build
-
-( set +x; UV_PUBLISH_TOKEN=$(security find-generic-password -a pypi -s mcp-zuul -w) uv publish )
-ok "Published to PyPI"
-
-# ── GitHub Release ───────────────────────────────────────────────────────────
-
-info "Creating GitHub Release"
-
-# Extract changelog section for this version
-NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found" CHANGELOG.md)
-[[ -n "$NOTES" ]] || NOTES="Release v${VERSION}"
-
-gh release create "v${VERSION}" --title "v${VERSION}" --notes "$NOTES"
-ok "GitHub Release created"
-
-# ── MCP Registry ─────────────────────────────────────────────────────────────
-
-info "Triggering MCP Registry publish"
-gh workflow run publish-registry.yml
-ok "MCP Registry workflow dispatched"
+ok "Tag v${VERSION} pushed (release.yml handles PyPI + GH release + Docker)"
 
 # ── Done ─────────────────────────────────────────────────────────────────────
 
@@ -163,4 +132,6 @@ echo "  GitHub:   https://github.com/imatza-rh/mcp-zuul/releases/tag/v${VERSION}
 echo "  Docker:   https://github.com/imatza-rh/mcp-zuul/actions/workflows/docker.yml"
 echo "  Registry: https://github.com/imatza-rh/mcp-zuul/actions/workflows/publish-registry.yml"
 echo ""
+echo "Note: release.yml workflow handles PyPI publish, GitHub Release,"
+echo "and MCP Registry dispatch automatically on tag push."
 echo "Remember to update CLAUDE.md if tool count changed."

--- a/scripts/generate_tool_docs.py
+++ b/scripts/generate_tool_docs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Generate docs/tools.md from registered MCP tool metadata."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import mcp_zuul  # noqa: E402,F401
+from mcp_zuul.server import mcp  # noqa: E402
+
+
+def _get_tools() -> dict[str, object]:
+    return {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+
+def _mode(tool: object) -> str:
+    annotations = getattr(tool, "annotations", None)
+    read_only = getattr(annotations, "read_only_hint", True)
+    return "read" if read_only is not False else "write"
+
+
+def generate() -> str:
+    tools = _get_tools()
+    lines = [
+        "# Tools Reference",
+        "",
+        "Auto-generated from the registered MCP tools. Do not edit by hand.",
+        "",
+        "| Tool | Mode | Description |",
+        "| --- | --- | --- |",
+    ]
+    for name in sorted(tools):
+        tool = tools[name]
+        description = (getattr(tool, "description", "") or "").splitlines()[0].strip()
+        description = description.replace("|", "\\|")
+        lines.append(f"| `{name}` | {_mode(tool)} | {description} |")
+    lines.extend([
+        "",
+        "---",
+        "",
+        "Write tools are disabled by default with `ZUUL_READ_ONLY=true`.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    output = Path(__file__).parent.parent / "docs" / "tools.md"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(generate(), encoding="utf-8")
+    print(f"Wrote {output}")

--- a/src/mcp_zuul/server.py
+++ b/src/mcp_zuul/server.py
@@ -36,7 +36,7 @@ class _BearerAuth(httpx.Auth):
     def __init__(self, token: str) -> None:
         self.token = token
 
-    def auth_flow(self, request: httpx.Request):  # type: ignore[override]
+    def auth_flow(self, request: httpx.Request):
         request.headers["Authorization"] = f"Bearer {self.token}"
         yield request
 


### PR DESCRIPTION
## Summary
Deep audit-driven hardening for CI supply-chain security, release automation, container metadata, security scanning, typing, and developer workflows.

## Changes
- Pin CI and Docker GitHub Actions to immutable commit SHAs (latest versions, verified via GitHub API).
- Add Docker SBOM, provenance, and registry attestation.
- Add OIDC-based PyPI release automation and GitHub Releases.
- Add CodeQL, dependency review, and weekly OpenSSF Scorecard scanning.
- Add OCI Docker labels and a non-network import healthcheck.
- Add safe mypy settings (strict_equality, warn_redundant_casts, warn_unused_ignores) while keeping disallow_untyped_defs=false.
- Update SECURITY.md supported versions and supply-chain guidance.
- Add Makefile CI, dependency-audit, release-check, and tool-doc generation targets.
- Add scripts/generate_tool_docs.py to generate a live MCP tool reference.

## Verification
- All 13 action SHAs verified via gh api repos/OWNER/REPO/git/ref/tags/vX.Y.Z (annotated tags dereferenced).
- All actions pinned to their latest available version.
- 880 tests pass, ruff lint+format clean, mypy clean.

## Maintainer setup required
- Configure the PyPI Trusted Publisher for workflow release.yml and GitHub environment release before tagging a release.
- Review pinned action SHAs periodically with Dependabot or Renovate.